### PR TITLE
Use commit hash when pulling instead of branch name

### DIFF
--- a/main.go
+++ b/main.go
@@ -98,8 +98,8 @@ func pull(r *plugin.Repo, b *plugin.Build) *exec.Cmd {
 	return exec.Command(
 		"hg",
 		"pull",
-		"--branch",
-		b.Branch,
+		"-r",
+		b.Commit,
 		r.Clone,
 	)
 }


### PR DESCRIPTION
On a bookmark, the branch name given is the bookmark name; so the update
fails.
Using the commit hash works in either case, and on top of it does not
pull the more recent commit on the branch (if any).
Fixes #9
