### PR TITLE
bugfix #16 - abort: http authorization

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -15,7 +15,7 @@ const hgrcFile = `
 [auth]
 drone.prefix = %s
 drone.username = %s
-drone.password %s
+drone.password = %s
 drone.schemes = http https
 `
 
@@ -36,7 +36,7 @@ func writeHgrc(machine, login, password string) error {
 	if err == nil {
 		home = u.HomeDir
 	}
-	path := filepath.Join(home, ".netrc")
+	path := filepath.Join(home, ".hgrc")
 	return ioutil.WriteFile(path, []byte(out), 0600)
 }
 


### PR DESCRIPTION
- fix bug #16
- Mercurial use `~/.hgrc` as authorization file

With current `plugins/hg`, I got exact same issue as #16 

```
docker run --rm \
>   -e DRONE_REMOTE_URL=https://bitbucket.org/orig/project-1 \
>   -e DRONE_WORKSPACE=/go/src/bitbucket.org/orig/project-1  \
>   -e DRONE_BUILD_EVENT=push \
>   -e DRONE_COMMIT_SHA=1234566300fcb59c434730da967338e70a3b \
>   -e DRONE_NETRC_MACHINE=https://bitbucket.org/orig \
>   -e DRONE_NETRC_USERNAME=<username> \
>   -e DRONE_NETRC_PASSWORD=<password> \
>   plugins/hg

$ hg init .
$ hg pull --rev 1234566300fcb59c434730da967338e70a3b https://bitbucket.org/orig/project-1
pulling from https://bitbucket.org/orig/project-1
abort: http authorization required for https://bitbucket.org/orig/project-1
time="2017-08-29T07:23:03Z" level=fatal msg="exit status 255"
```

After fix the bug, I can use my own build image to successfully `hg clone` the image, 👍  

```
docker run --rm \
>   -e DRONE_REMOTE_URL=https://bitbucket.org/orig/project-1 \
>   -e DRONE_WORKSPACE=/go/src/bitbucket.org/orig/project-1  \
>   -e DRONE_BUILD_EVENT=push \
>   -e DRONE_COMMIT_SHA=1234566300fcb59c434730da967338e70a3b \
>   -e DRONE_NETRC_MACHINE=https://bitbucket.org/orig \
>   -e DRONE_NETRC_USERNAME=<username> \
>   -e DRONE_NETRC_PASSWORD=<password> \
>   ozbillwang/hg
$ hg init .
$ hg pull --rev 87628ac7dd0300fcb59c434730da967338e70a3b https://bitbucket.org/orig/project-1
pulling from https://bitbucket.org/orig/project-1
adding changesets
adding manifests
adding file changes
added 1017 changesets with 1987 changes to 482 files
(run 'hg update' to get a working copy)
```


But not sure how to  use in drone pipeline. 



@tboerger , @bradrydzewski 

I tried to use the new image in drone pipeline as below, but still fail.

```
clone:
  hg:
    image: ozbillwang/hg
    path: orig/project-1
    netrc.machine: https://bitbucket.org/orig
    netrc.username: <username>
    netrc.password: <username>
```
And this

```
clone:
  hg:
    image: ozbillwang/hg
    path: orig/project-1
    machine: https://bitbucket.org/orig
    username: <username>
    password: <username>
```

Any hints for me?