### PR TITLE
Add support for pooled storage

### DIFF
--- a/main.go
+++ b/main.go
@@ -54,6 +54,11 @@ func main() {
 			Usage:  "netrc password",
 			EnvVar: "DRONE_NETRC_PASSWORD",
 		},
+		cli.StringFlag{
+			Name:   "share.pool",
+			Usage:  "pool storage",
+			EnvVar: "HG_SHARE_POOL",
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -75,6 +80,9 @@ func run(c *cli.Context) error {
 			Machine:  c.String("netrc.machine"),
 			Login:    c.String("netrc.username"),
 			Password: c.String("netrc.password"),
+		},
+		Share: Share{
+			Pool: c.String("share.pool"),
 		},
 	}
 

--- a/types.go
+++ b/types.go
@@ -16,4 +16,8 @@ type (
 		Login    string
 		Password string
 	}
+
+	Share struct {
+		Pool     string
+	}
 )

--- a/utils.go
+++ b/utils.go
@@ -19,17 +19,24 @@ drone.password = %s
 drone.schemes = http https
 `
 
+const shareConf = `
+[extensions]
+hgext.share =
+[share]
+pool = %s
+`
+
 // helper function to write a hgrc file.
 func writeHgrc(machine, login, password string) error {
-	if machine == "" {
-		return nil
+	out := ""
+	if machine != "" {
+		out = fmt.Sprintf(
+			hgrcFile,
+			machine,
+			login,
+			password,
+		)
 	}
-	out := fmt.Sprintf(
-		hgrcFile,
-		machine,
-		login,
-		password,
-	)
 
 	home := "/root"
 	u, err := user.Current()
@@ -38,6 +45,23 @@ func writeHgrc(machine, login, password string) error {
 	}
 	path := filepath.Join(home, ".hgrc")
 	return ioutil.WriteFile(path, []byte(out), 0600)
+}
+
+func addShare(path string) error {
+	content := fmt.Sprintf(
+		shareConf,
+		path,
+	)
+	return appendHgrc(content)
+}
+
+func appendHgrc(content string) error {
+	file, err := os.OpenFile("/root/.hgrc", os.O_WRONLY|os.O_APPEND, 0600)
+	if err != nil {
+		return err
+	}
+	_, err = file.WriteString(content)
+	return err
 }
 
 // helper function returns true if directory dir is empty.


### PR DESCRIPTION
In order to limit the bandwidth when cloning, we could use a pool storage.
I added a new flag `HG_SHARE_POOL`. If it is set, mercurial will use this directory as pool storage (see https://www.mercurial-scm.org/doc/hg.1.html#share).